### PR TITLE
13 timestamp, custom user extensions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,12 +1,13 @@
 
 project('fortran-messagepack', ['fortran'],
-    version : '0.0.1')
+    version : '0.1.0')
 
 my_lib = shared_library('messagepack',
     'src/messagepack.f90',
     'src/messagepack_value.f90',
     'src/messagepack_pack.f90',
     'src/messagepack_unpack.f90',
+    'src/messagepack_user.f90',
     'src/byte_utilities.f90')
 
 my_dep = declare_dependency(link_with : my_lib)

--- a/meson.build
+++ b/meson.build
@@ -1,13 +1,13 @@
 
 project('fortran-messagepack', ['fortran'],
-    version : '0.1.0')
+    version : '0.1.1')
 
 my_lib = shared_library('messagepack',
     'src/messagepack.f90',
     'src/messagepack_value.f90',
+    'src/messagepack_user.f90',
     'src/messagepack_pack.f90',
     'src/messagepack_unpack.f90',
-    'src/messagepack_user.f90',
     'src/byte_utilities.f90')
 
 my_dep = declare_dependency(link_with : my_lib)

--- a/src/messagepack.f90
+++ b/src/messagepack.f90
@@ -9,6 +9,7 @@ module messagepack
     use messagepack_value
     use messagepack_pack
     use messagepack_unpack
+    use messagepack_user
     use byte_utilities
     implicit none
 contains

--- a/src/messagepack.f90
+++ b/src/messagepack.f90
@@ -8,9 +8,10 @@ module messagepack
     use iso_fortran_env
     use messagepack_value
     use messagepack_pack
-    use messagepack_unpack
     use messagepack_user
+    use messagepack_unpack
     use byte_utilities
+
     implicit none
 contains
     subroutine print_version()

--- a/src/messagepack_unpack.f90
+++ b/src/messagepack_unpack.f90
@@ -1,8 +1,9 @@
 module messagepack_unpack
     use iso_fortran_env
-    use,intrinsic :: ieee_arithmetic
+    use, intrinsic :: ieee_arithmetic
     use byte_utilities
     use messagepack_value
+    use messagepack_user
 
     implicit none
 
@@ -23,10 +24,11 @@ module messagepack_unpack
             end if
         end function
 
-        subroutine unpack_stream(buffer, mpv, successful)
+        subroutine unpack_stream(settings, buffer, mpv, successful)
             ! @param[in] buffer - input byte buffer containing messagepack data
             ! @param[out] successful - did unpacking succeed
             ! @param[out] error - If an error occurred, returns a message with why
+            class(mp_settings), intent(in) :: settings
             byte, dimension(:), intent(in) :: buffer
             class(mp_value_type), allocatable, intent(out) :: mpv
             integer(kind=int64) :: byteadvance
@@ -38,10 +40,12 @@ module messagepack_unpack
             little_endian = detect_little_endian()
 
             successful = .true.   ! initially set to true
-            call unpack_value(buffer, byteadvance, little_endian, mpv, successful)
+            call unpack_value(settings, buffer, byteadvance, little_endian, mpv, successful)
         end subroutine
 
-        recursive subroutine unpack_value(buffer, byteadvance, is_little_endian, mpv, successful)
+        recursive subroutine unpack_value(settings, buffer, byteadvance, &
+                is_little_endian, mpv, successful)
+            class(mp_settings), intent(in) :: settings
             byte, dimension(:), intent(in) :: buffer
             integer(kind=int64), intent(out) :: byteadvance
             logical, intent(in) :: is_little_endian
@@ -93,7 +97,8 @@ module messagepack_unpack
                     return
                 end if
                 byteadvance = 2 ! start at next object
-                call unpack_map(val_int64, buffer, byteadvance, is_little_endian, mpv, successful)
+                call unpack_map(settings, val_int64, buffer, byteadvance, &
+                    is_little_endian, mpv, successful)
             case (MP_FA_L:MP_FA_H)
                 btemp1 = 0
                 call mvbits(buffer(1), 0, 4, btemp1, 0) ! get fixarray length
@@ -102,7 +107,8 @@ module messagepack_unpack
                     return
                 end if
                 byteadvance = 2 ! start at next object
-                call unpack_array(btemp1 + 0_int64, buffer, byteadvance, is_little_endian, mpv, successful)
+                call unpack_array(settings, btemp1 + 0_int64, buffer, byteadvance, &
+                    is_little_endian, mpv, successful)
             case (MP_FS_L:MP_FS_H)
                 btemp1 = 0
                 call mvbits(buffer(1), 0, 5, btemp1, 0) ! get fixstr length
@@ -188,7 +194,8 @@ module messagepack_unpack
                     return
                 end if
                 i = buffer(3)
-                call unpack_ext(int8_as_unsigned(buffer(2)) + 0_int64, i, buffer(4:), byteadvance, mpv, successful)
+                call unpack_ext(settings, int8_as_unsigned(buffer(2)) + 0_int64, &
+                    i, buffer(4:), byteadvance, is_little_endian, mpv, successful)
             case (MP_E16)
                 ! check for first 4 bytes
                 if (.not. check_length_and_print(4_int64, length)) then
@@ -197,7 +204,8 @@ module messagepack_unpack
                 end if
                 i = buffer(4)
                 val_int16 = bytes_be_to_int_2(buffer(2:3), is_little_endian)
-                call unpack_ext(val_int16 + 0_int64, i, buffer(5:), byteadvance, mpv, successful)
+                call unpack_ext(settings, val_int16 + 0_int64, &
+                    i, buffer(5:), byteadvance, is_little_endian, mpv, successful)
             case (MP_E32)
                 ! check for first 6 bytes
                 if (.not. check_length_and_print(6_int64, length)) then
@@ -206,7 +214,8 @@ module messagepack_unpack
                 end if
                 i = buffer(6)
                 val_int32 = bytes_be_to_int_4(buffer(2:5), is_little_endian)
-                call unpack_ext(val_int32 + 0_int64, i, buffer(7:), byteadvance, mpv, successful)
+                call unpack_ext(settings, val_int32 + 0_int64, &
+                    i, buffer(7:), byteadvance, is_little_endian, mpv, successful)
             case (MP_F32)
                 ! 4 bytes following
                 if (.not. check_length_and_print(5_int64, length)) then
@@ -309,7 +318,8 @@ module messagepack_unpack
                 end if
                 i = buffer(2)
                 byteadvance = 2
-                call unpack_ext(1_int64, i, buffer(3:), byteadvance, mpv, successful)
+                call unpack_ext(settings, 1_int64, &
+                    i, buffer(3:), byteadvance, is_little_endian, mpv, successful)
             case (MP_FE2)
                 ! 4 bytes following
                 if (.not. check_length_and_print(4_int64, length)) then
@@ -318,7 +328,8 @@ module messagepack_unpack
                 end if
                 i = buffer(2)
                 byteadvance = 2
-                call unpack_ext(2_int64, i, buffer(3:), byteadvance, mpv, successful)
+                call unpack_ext(settings, 2_int64, &
+                    i, buffer(3:), byteadvance, is_little_endian, mpv, successful)
             case (MP_FE4)
                 ! 6 bytes following
                 if (.not. check_length_and_print(6_int64, length)) then
@@ -327,7 +338,8 @@ module messagepack_unpack
                 end if
                 i = buffer(2)
                 byteadvance = 2
-                call unpack_ext(4_int64, i, buffer(3:), byteadvance, mpv, successful)
+                call unpack_ext(settings, 4_int64, &
+                    i, buffer(3:), byteadvance, is_little_endian, mpv, successful)
             case (MP_FE8)
                 ! 8 bytes following
                 if (.not. check_length_and_print(8_int64, length)) then
@@ -336,7 +348,8 @@ module messagepack_unpack
                 end if
                 i = buffer(2)
                 byteadvance = 2
-                call unpack_ext(8_int64, i, buffer(3:), byteadvance, mpv, successful)
+                call unpack_ext(settings, 8_int64, &
+                    i, buffer(3:), byteadvance, is_little_endian, mpv, successful)
             case (MP_FE16)
                 ! 18 bytes following
                 if (.not. check_length_and_print(18_int64, length)) then
@@ -345,7 +358,8 @@ module messagepack_unpack
                 end if
                 i = buffer(2)
                 byteadvance = 2
-                call unpack_ext(16_int64, i, buffer(3:), byteadvance, mpv, successful)
+                call unpack_ext(settings, 16_int64, &
+                    i, buffer(3:), byteadvance, is_little_endian, mpv, successful)
             case (MP_S8)
                 ! check that the remaining number of bytes exist
                 val_int16 = int8_as_unsigned(buffer(2))
@@ -399,7 +413,8 @@ module messagepack_unpack
                     return
                 end if
                 byteadvance = 4 ! start at next object
-                call unpack_array(int(val_int32, kind=int64), buffer, byteadvance, is_little_endian, mpv, successful)
+                call unpack_array(settings, int(val_int32, kind=int64), &
+                    buffer, byteadvance, is_little_endian, mpv, successful)
             case (MP_A32)
                 ! check that the remaining number of bytes exist
                 val_int32 = bytes_be_to_int_4(buffer(2:5), is_little_endian)
@@ -409,7 +424,8 @@ module messagepack_unpack
                     return
                 end if
                 byteadvance = 6 ! start at next object
-                call unpack_array(val_int64, buffer, byteadvance, is_little_endian, mpv, successful)
+                call unpack_array(settings, val_int64, buffer, byteadvance, &
+                    is_little_endian, mpv, successful)
             case (MP_M16)
                 ! check that the remaining number of bytes exist
                 val_int16 = bytes_be_to_int_2(buffer(2:3), is_little_endian)
@@ -419,7 +435,8 @@ module messagepack_unpack
                     return
                 end if
                 byteadvance = 4 ! start at next object
-                call unpack_map(0_int64 + val_int32, buffer, byteadvance, is_little_endian, mpv, successful)
+                call unpack_map(settings, 0_int64 + val_int32, buffer, byteadvance, &
+                    is_little_endian, mpv, successful)
             case (MP_M32)
                 ! check that the remaining number of bytes exist
                 val_int32 = bytes_be_to_int_4(buffer(2:5), is_little_endian)
@@ -429,7 +446,8 @@ module messagepack_unpack
                     return
                 end if
                 byteadvance = 6 ! start at next object
-                call unpack_map(val_int64, buffer, byteadvance, is_little_endian, mpv, successful)
+                call unpack_map(settings, val_int64, buffer, byteadvance, &
+                    is_little_endian, mpv, successful)
             case (MP_NFI_L:MP_NFI_H)
                 ! take the first 5 bits, create a negative value from it
                 btemp1 = ibits(buffer(1), 0, 5)
@@ -437,7 +455,9 @@ module messagepack_unpack
             end select
         end subroutine
 
-        recursive subroutine unpack_array(length, buffer, byteadvance, is_little_endian, mpv, successful)
+        recursive subroutine unpack_array(settings, length, buffer, &
+                byteadvance, is_little_endian, mpv, successful)
+            class(mp_settings), intent(in) :: settings
             integer(kind=int64), intent(in) :: length
             byte, dimension(:), intent(in) :: buffer
             integer(kind=int64), intent(inout) :: byteadvance
@@ -449,7 +469,8 @@ module messagepack_unpack
             class(mp_value_type), allocatable :: val_any
             mpv = mp_arr_type(length)
             do i = 1,length
-                call unpack_value(buffer(byteadvance:), tmp, is_little_endian, val_any, successful)
+                call unpack_value(settings, buffer(byteadvance:), tmp, &
+                    is_little_endian, val_any, successful)
                 byteadvance = byteadvance + tmp
                 if (.not. successful) then
                     deallocate(mpv)
@@ -469,7 +490,9 @@ module messagepack_unpack
             end do
         end subroutine
 
-        recursive subroutine unpack_map(length, buffer, byteadvance, is_little_endian, mpv, successful)
+        recursive subroutine unpack_map(settings, length, buffer, byteadvance, &
+                is_little_endian, mpv, successful)
+            class(mp_settings), intent(in) :: settings
             integer(kind=int64), intent(in) :: length
             byte, dimension(:), intent(in) :: buffer
             integer(kind=int64), intent(inout) :: byteadvance
@@ -484,7 +507,8 @@ module messagepack_unpack
             mpv = mp_map_type(length)
             do i = 1,length
                 ! get key
-                call unpack_value(buffer(byteadvance:), tmp, is_little_endian, val_any, successful)
+                call unpack_value(settings, buffer(byteadvance:), &
+                    tmp, is_little_endian, val_any, successful)
                 byteadvance = byteadvance + tmp
                 if (.not. successful) then
                     deallocate(mpv)
@@ -501,7 +525,8 @@ module messagepack_unpack
                 end select
 
                 ! get value
-                call unpack_value(buffer(byteadvance:), tmp, is_little_endian, val_any, successful)
+                call unpack_value(settings, buffer(byteadvance:), tmp, &
+                    is_little_endian, val_any, successful)
                 byteadvance = byteadvance + tmp
                 if (.not. successful) then
                     deallocate(mpv)
@@ -519,19 +544,47 @@ module messagepack_unpack
             end do
         end subroutine
 
-        subroutine unpack_ext(length, etype, buffer, byteadvance, mpv, successful)
+        subroutine unpack_ext(settings, length, etype, buffer, byteadvance, &
+                is_little_endian, mpv, successful)
+            class(mp_settings), intent(in) :: settings
             integer(kind=int64), intent(in) :: length
             integer, intent(in) :: etype
             byte, dimension(:), intent(in) :: buffer
             integer(kind=int64), intent(inout) :: byteadvance
+            logical, intent(in) :: is_little_endian
             class(mp_value_type), allocatable, intent(out) :: mpv
             logical, intent(out) :: successful
+
+            integer :: ind
 
             if (length > size(buffer)) then
                 successful = .false.
                 return
             end if
 
+            ! Custom extension handling
+            ind = etype + 128
+            if (length == 1) then
+                if (associated(settings%f1(ind)%cb)) then
+                    call settings%f1(ind)%cb(buffer, byteadvance, &
+                        is_little_endian, mpv, successful)
+                    return
+                end if
+            else if (length == 2) then
+                if (associated(settings%f2(ind)%cb)) then
+                    call settings%f2(ind)%cb(buffer, byteadvance, &
+                        is_little_endian, mpv, successful)
+                    return
+                end if
+            else if (length == 4) then
+                if (associated(settings%f4(ind)%cb)) then
+                    call settings%f4(ind)%cb(buffer, byteadvance, &
+                        is_little_endian, mpv, successful)
+                    return
+                end if
+            end if
+
+            ! regular extension
             mpv = mp_ext_type(etype, length)
             successful = .true.
             select type(mpv)

--- a/src/messagepack_unpack.f90
+++ b/src/messagepack_unpack.f90
@@ -452,6 +452,7 @@ module messagepack_unpack
                 call unpack_value(buffer(byteadvance:), tmp, is_little_endian, val_any, successful)
                 byteadvance = byteadvance + tmp
                 if (.not. successful) then
+                    deallocate(mpv)
                     return
                 end if
 
@@ -462,6 +463,7 @@ module messagepack_unpack
                     mpv%value(i)%obj = val_any
                 class default
                     successful = .false.
+                    deallocate(mpv)
                     print *, "[Error: something went terribly wrong"
                 end select
             end do
@@ -485,6 +487,7 @@ module messagepack_unpack
                 call unpack_value(buffer(byteadvance:), tmp, is_little_endian, val_any, successful)
                 byteadvance = byteadvance + tmp
                 if (.not. successful) then
+                    deallocate(mpv)
                     return
                 end if
                 select type (mpv)
@@ -493,6 +496,7 @@ module messagepack_unpack
                     mpv%keys(i)%obj = val_any
                 class default
                     successful = .false.
+                    deallocate(mpv)
                     print *, "[Error: something went terribly wrong"
                 end select
 
@@ -500,6 +504,7 @@ module messagepack_unpack
                 call unpack_value(buffer(byteadvance:), tmp, is_little_endian, val_any, successful)
                 byteadvance = byteadvance + tmp
                 if (.not. successful) then
+                    deallocate(mpv)
                     return
                 end if
                 select type (mpv)
@@ -508,6 +513,7 @@ module messagepack_unpack
                     mpv%values(i)%obj = val_any
                 class default
                     successful = .false.
+                    deallocate(mpv)
                     print *, "[Error: something went terribly wrong"
                 end select
             end do
@@ -535,6 +541,7 @@ module messagepack_unpack
                 byteadvance = byteadvance + length
             class default
                 successful = .false.
+                deallocate(mpv)
                 print *, "[Error: something went terribly wrong"
             end select
         end subroutine

--- a/src/messagepack_user.f90
+++ b/src/messagepack_user.f90
@@ -1,0 +1,194 @@
+! defines a class that stores callbacks for handling
+! user extensions
+module messagepack_user
+    use iso_fortran_env
+    use, intrinsic :: ieee_arithmetic
+    use messagepack_value
+    use byte_utilities
+
+    implicit none
+
+    integer, parameter, public :: MP_TS_EXT = -1
+
+    private
+
+    public :: mp_settings
+    public :: mp_timestamp_type
+
+    ! defines settings used for serialization & deserialization with
+    ! this library.
+    ! - stores 
+    type :: mp_settings
+        logical, dimension(256) :: is_registered ! is a type registered
+    contains
+        procedure :: register_extension
+        procedure :: register_extension_super
+    end type
+    interface mp_settings
+        procedure :: new_settings
+    end interface
+    
+    ! #region messagepack defined extensions go here
+    type, extends(mp_value_type) :: mp_timestamp_type
+        integer(kind=int64) :: seconds
+        integer(kind=int64) :: nanoseconds
+    contains
+        procedure :: getsize => get_size_timestamp
+        procedure :: pack => pack_timestamp
+    end type
+    interface mp_timestamp_type
+        procedure :: new_timestamp
+    end interface
+    ! #endregion
+
+    contains
+        type(mp_settings) function new_settings()
+            integer :: i
+            logical :: err
+            do i = 1,256
+                new_settings%is_registered(i) = .false.
+            end do
+
+            ! add timestamp here
+            call new_settings%register_extension_super(-1_int8, err)
+        end function
+
+        type(mp_timestamp_type) function new_timestamp(sec, ns)
+            integer(kind=int64) :: sec
+            integer(kind=int64) :: ns
+            new_timestamp%seconds     = sec
+            new_timestamp%nanoseconds = ns
+        end function
+
+        subroutine register_extension(this, typeid, error)
+            ! Registers callbacks for handling extensions
+            ! Only allows registering ids [0 127]
+            class(mp_settings) :: this
+            integer(kind=int8), intent(in) :: typeid
+            logical, intent(out) :: error
+
+            if (typeid < 0) then
+                error = .true.
+                return
+            end if
+            call this%register_extension_super(typeid, error)
+        end subroutine
+
+        subroutine register_extension_super(this, typeid, error)
+            ! Registers callbacks for handling extensions
+            ! allows ids [-128 127]
+            class(mp_settings) :: this
+            integer(kind=int8), intent(in) :: typeid
+            logical, intent(out) :: error
+            integer :: arr_index
+
+            arr_index = typeid + 128 ! [-128, 127] -> [1, 256]
+            if (this%is_registered(arr_index)) then
+                error = .true.
+                return
+            end if
+
+            this%is_registered(arr_index) = .true.
+            error = .false.
+        end subroutine
+
+        subroutine get_size_timestamp(this, osize)
+            class(mp_timestamp_type) :: this
+            integer(kind=int64), intent(out) :: osize
+            if (this%nanoseconds == 0 .and. this%seconds <= 4294967296_int64) then
+                osize = 6  ! timestamp32
+            else if (this%nanoseconds <= 1073741824_int64 &
+                .and. this%seconds <= 17179869184_int64) then
+                ! nanoseconds fit into uint30, seconds fit into uint34
+                osize = 10 ! timestamp32
+            else
+                osize = 15 ! timestamp96
+            end if
+        end subroutine
+
+        subroutine pack_timestamp(this, buf, error)
+            class(mp_timestamp_type) :: this
+            byte, dimension(:) :: buf
+            logical, intent(out) :: error
+
+            integer(kind=int64) :: temp
+            integer(kind=int64) :: replength
+            call this%getsize(replength)
+            if (replength > size(buf)) then
+                error = .true.
+                return
+            end if
+
+            select case (replength)
+            case (6)  ! timestamp32
+                buf(1) = MP_FE4
+                buf(2) = MP_TS_EXT
+                call int_to_bytes_be_4(buf(3:6), int(this%seconds, kind=int32))
+            case (10) ! timestamp64
+                buf(1) = MP_FE8
+                buf(2) = MP_TS_EXT
+                temp = 0_int64
+                !call mvbits(this%)
+                !call mvbits
+            case (15) ! timestamp96
+                buf(1) = MP_E8
+                buf(2) = 12
+                buf(3) = MP_TS_EXT
+                call int_to_bytes_be_4(buf(4:7), int(this%nanoseconds, kind=int32))
+                call int_to_bytes_be_8(buf(8:15), this%seconds)
+            end select
+
+            error = .false.
+        end subroutine
+
+        subroutine unpack_timestamp_32(buffer, byteadvance, is_little_endian, mpv, successful)
+            byte, dimension(:), intent(in) :: buffer
+            integer(kind=int64), intent(inout) :: byteadvance
+            logical, intent(in) :: is_little_endian
+            class(mp_value_type), allocatable, intent(out) :: mpv
+            logical, intent(out) :: successful
+
+            integer(kind=int32) :: temp
+
+            if (size(buffer(byteadvance:)) < 6) then
+                successful = .false.
+                return
+            end if
+
+            byteadvance = byteadvance + 2
+            temp = bytes_be_to_int_4(buffer(byteadvance:byteadvance+3), is_little_endian)
+            mpv = mp_timestamp_type(temp, 0)
+            byteadvance = byteadvance + 3
+
+            successful = .true.
+        end subroutine
+
+        subroutine unpack_timestamp_96(buffer, byteadvance, is_little_endian, mpv, successful)
+            byte, dimension(:), intent(in) :: buffer
+            integer(kind=int64), intent(inout) :: byteadvance
+            logical, intent(in) :: is_little_endian
+            class(mp_value_type), allocatable, intent(out) :: mpv
+            logical, intent(out) :: successful
+
+            integer(kind=int32) :: temp
+            integer(kind=int64) :: temp2
+
+            if (size(buffer(byteadvance:)) < 15) then
+                successful = .false.
+                return
+            end if
+            if (buffer(byteadvance + 1) /= 12) then
+                successful = .false.
+                return
+            end if
+
+            byteadvance = byteadvance + 2
+            temp = bytes_be_to_int_4(buffer(byteadvance:byteadvance+3), is_little_endian)
+            byteadvance = byteadvance + 4
+            temp2 = bytes_be_to_int_8(buffer(byteadvance:byteadvance+7), is_little_endian)
+            mpv = mp_timestamp_type(temp2, temp)
+            byteadvance = byteadvance + 7
+
+            successful = .true.
+        end subroutine
+end module

--- a/src/messagepack_user.f90
+++ b/src/messagepack_user.f90
@@ -11,7 +11,7 @@ module messagepack_user
     private
 
     public :: mp_settings, unpack_func, unpack_callback
-    public :: mp_timestamp_type, register_extension
+    public :: mp_timestamp_type, is_timestamp, get_timestamp_ref, register_extension
 
     integer, parameter, public :: MP_TS_EXT = -1
     
@@ -42,6 +42,14 @@ module messagepack_user
         class(unpack_callback), allocatable, dimension(:) :: e8
         class(unpack_callback), allocatable, dimension(:) :: e16
         class(unpack_callback), allocatable, dimension(:) :: e32
+        logical, dimension(256) :: f1_allocated
+        logical, dimension(256) :: f2_allocated
+        logical, dimension(256) :: f4_allocated
+        logical, dimension(256) :: f8_allocated
+        logical, dimension(256) :: f16_allocated
+        logical, dimension(256) :: e8_allocated
+        logical, dimension(256) :: e16_allocated
+        logical, dimension(256) :: e32_allocated
     contains
         procedure :: register_extension
         procedure :: register_extension_super
@@ -67,6 +75,7 @@ module messagepack_user
         type(mp_settings) function new_settings()
             logical :: err
             procedure(unpack_func), pointer :: p
+            integer :: i
             allocate(new_settings%f1(256))
             allocate(new_settings%f2(256))
             allocate(new_settings%f4(256))
@@ -75,6 +84,16 @@ module messagepack_user
             allocate(new_settings%e8(256))
             allocate(new_settings%e16(256))
             allocate(new_settings%e32(256))
+            do i = 1,256
+                new_settings%f1_allocated = .false.
+                new_settings%f2_allocated = .false.
+                new_settings%f4_allocated = .false.
+                new_settings%f8_allocated = .false.
+                new_settings%f16_allocated = .false.
+                new_settings%e8_allocated = .false.
+                new_settings%e16_allocated = .false.
+                new_settings%e32_allocated = .false.
+            end do
 
             ! add timestamp here
             p => unpack_timestamp_32
@@ -82,14 +101,14 @@ module messagepack_user
             p => unpack_timestamp_64
             call new_settings%register_extension_super(MP_FE8, -1_int8, p, err)
             p => unpack_timestamp_96
-            call new_settings%register_extension_super(MP_FE8, -1_int8, p, err)
+            call new_settings%register_extension_super(MP_E8, -1_int8, p, err)
         end function
 
         type(mp_timestamp_type) function new_timestamp(sec, ns)
             integer(kind=int64) :: sec
             integer(kind=int64) :: ns
             new_timestamp%seconds     = sec
-            new_timestamp%nanoseconds = ns
+            new_timestamp%nanoseconds = abs(ns)
         end function
 
         subroutine register_extension(this, ext, typeid, cb, error)
@@ -124,20 +143,28 @@ module messagepack_user
             select case(ext)
             case (MP_FE1)
                 this%f1(arr_index)%cb => cb
+                this%f1_allocated(arr_index) = .true.
             case (MP_FE2)
                 this%f2(arr_index)%cb => cb
+                this%f2_allocated(arr_index) = .true.
             case (MP_FE4)
                 this%f4(arr_index)%cb => cb
+                this%f4_allocated(arr_index) = .true.
             case (MP_FE8)
                 this%f8(arr_index)%cb => cb
+                this%f8_allocated(arr_index) = .true.
             case (MP_FE16)
                 this%f16(arr_index)%cb => cb
+                this%f16_allocated(arr_index) = .true.
             case (MP_E8)
                 this%e8(arr_index)%cb => cb
+                this%e8_allocated(arr_index) = .true.
             case (MP_E16)
                 this%e16(arr_index)%cb => cb
+                this%e16_allocated(arr_index) = .true.
             case (MP_E32)
                 this%e32(arr_index)%cb => cb
+                this%e16_allocated(arr_index) = .true.
             end select
 
             error = .false.
@@ -146,10 +173,12 @@ module messagepack_user
         subroutine get_size_timestamp(this, osize)
             class(mp_timestamp_type) :: this
             integer(kind=int64), intent(out) :: osize
-            if (this%nanoseconds == 0 .and. this%seconds <= 4294967296_int64) then
+            if (this%nanoseconds == 0 .and. this%seconds <= 4294967296_int64 .and. &
+                    this%seconds >= 0) then
                 osize = 6  ! timestamp32
-            else if (this%nanoseconds <= 1073741824_int64 &
-                .and. this%seconds <= 17179869184_int64) then
+            else if (this%nanoseconds  <=  1073741824_int64 &
+                    .and. this%seconds <= 17179869184_int64 &
+                    .and. this%seconds >= 0) then
                 ! nanoseconds fit into uint30, seconds fit into uint34
                 osize = 10 ! timestamp32
             else
@@ -202,12 +231,11 @@ module messagepack_user
 
             integer(kind=int32) :: temp
 
-            if (size(buffer(byteadvance:)) < 6) then
+            if (size(buffer(byteadvance:)) < 4) then
                 successful = .false.
                 return
             end if
 
-            byteadvance = byteadvance + 2
             temp = bytes_be_to_int_4(buffer(byteadvance:byteadvance+3), is_little_endian)
             mpv = mp_timestamp_type(temp, 0)
             byteadvance = byteadvance + 3
@@ -224,13 +252,14 @@ module messagepack_user
 
             integer(kind=int64) :: temp, temp1, temp2
 
-            if (size(buffer(byteadvance:)) < 10) then
+            if (size(buffer(byteadvance:)) < 8) then
                 successful = .false.
                 return
             end if
-            
-            byteadvance = byteadvance + 2
+
             temp = bytes_be_to_int_8(buffer(byteadvance:byteadvance+7), is_little_endian)
+            temp1 = 0
+            temp2 = 0
             call mvbits(temp, 0, 34, temp1, 0)
             call mvbits(temp, 34, 30, temp2, 0)
             mpv = mp_timestamp_type(temp1, temp2)
@@ -249,22 +278,45 @@ module messagepack_user
             integer(kind=int32) :: temp
             integer(kind=int64) :: temp2
 
-            if (size(buffer(byteadvance:)) < 15) then
-                successful = .false.
-                return
-            end if
-            if (buffer(byteadvance + 1) /= 12) then
+            if (size(buffer(byteadvance:)) /= 12) then
                 successful = .false.
                 return
             end if
 
-            byteadvance = byteadvance + 2
             temp = bytes_be_to_int_4(buffer(byteadvance:byteadvance+3), is_little_endian)
             byteadvance = byteadvance + 4
             temp2 = bytes_be_to_int_8(buffer(byteadvance:byteadvance+7), is_little_endian)
             mpv = mp_timestamp_type(temp2, temp)
-            byteadvance = byteadvance + 7
+            byteadvance = byteadvance + 8
 
             successful = .true.
+        end subroutine
+
+        function is_timestamp(obj) result(res)
+            class(mp_value_type), intent(in) :: obj
+            logical :: res
+
+            select type(obj)
+            type is(mp_value_type)
+            class is (mp_timestamp_type)
+                res = .true.
+            class default
+                res = .false.
+            end select
+        end function is_timestamp
+
+        subroutine get_timestamp_ref(obj, val, stat)
+            class(mp_value_type), intent(in) :: obj
+            class(mp_timestamp_type), allocatable, intent(out) :: val
+            logical, intent(out) :: stat
+
+            select type(obj)
+            type is (mp_value_type)
+            class is (mp_timestamp_type)
+                val = obj
+                stat = .true.
+            class default
+                stat = .false.
+            end select
         end subroutine
 end module

--- a/test/constructors.f90
+++ b/test/constructors.f90
@@ -12,6 +12,8 @@ program constructors
     type(mp_bin_type)  :: bin_test
     type(mp_ext_type)  :: ext_test
 
+    type(mp_timestamp_type) :: timestamp_test
+
     print *, 'Constructor Test'
 
     nil_test  = mp_nil_type()
@@ -54,4 +56,7 @@ program constructors
     ext_test%values(5) = 17
     ext_test%values(6) = -34
     ext_test%values(7) = -42
+
+    ! timestamp test
+    timestamp_test = mp_timestamp_type(14, 100023)
 end program

--- a/test/packing.f90
+++ b/test/packing.f90
@@ -9,6 +9,7 @@ program packing
     class(mp_arr_type), allocatable :: arr_test
     class(mp_map_type), allocatable :: map_test
     class(mp_ext_type), allocatable :: ext_test
+    clasS(mp_timestamp_type), allocatable :: ts_test
 
     byte, allocatable, dimension(:) :: buf
     character(:), allocatable :: small_text
@@ -407,5 +408,104 @@ program packing
     deallocate(ext_test)
     deallocate(b_var_temp)
     print *, "[Info: Ext32 packing test succeeded"
+
+    ! timestamp32 test
+    ts_test = mp_timestamp_type(50, 0)
+    call pack_alloc(ts_test, buf, errored)
+    if (errored) then
+        print *, "[Error: failed to pack timestamp32"
+        stop 1
+    end if
+    ! expect 6 bytes
+    b_6_temp = (/MP_FE4,-1,0,0,0,50/)
+    if (size(buf) == 6) then
+        do i = 1,6
+            if (buf(i) /= b_6_temp(i)) then
+                print *, "[Error: packed timestamp32 byte[]", i, "] ==", buf(i), "Expected:", b_6_temp(i)
+                stop 1
+            end if
+        end do
+    else
+        print *, "[Error: failed to pack timestamp32. Size:", size(buf), "Expected: 6"
+        stop 1
+    end if
+    deallocate(ts_test)
+    print *, "[Info: timestamp32 packing test succeeded"
+
+    ! timestamp64 test
+    ! 0x000003a0 000088b8
+    ts_test = mp_timestamp_type(35000, 232)
+    call pack_alloc(ts_test, buf, errored)
+    if (errored) then
+        print *, "[Error: failed to pack timestamp64"
+        stop 1
+    end if
+    ! expect 10 bytes
+    b_10_temp(1) = MP_FE8
+    b_10_temp(2) = -1_int8
+    b_10_temp(3) = 0
+    b_10_temp(4) = 0
+    b_10_temp(5) = 3
+    b_10_temp(6) = -96 ! 0xa0
+    b_10_temp(7) = 0
+    b_10_temp(8) = 0
+    b_10_temp(9) = -120 ! 0x88
+    b_10_temp(10) = -72 ! 0xb8
+    if (size(buf) == 10) then
+        do i = 1,10
+            if (buf(i) /= b_10_temp(i)) then
+                print *, "[Error: packed timestamp64 byte[]", i, "] ==", buf(i), "Expected:", b_6_temp(i)
+                stop 1
+            end if
+        end do
+    else
+        print *, "[Error: failed to pack timestamp64. Size:", size(buf), "Expected: 8"
+        stop 1
+    end if
+    deallocate(buf)
+    deallocate(ts_test)
+    print *, "[Info: timestamp64 packing test succeeded"
+
+    ! timestamp96 test
+    ! 0x000004d2
+    ! 0xfffffffffffff830
+    ts_test = mp_timestamp_type(-2000, 1234)
+    call pack_alloc(ts_test, buf, errored)
+    if (errored) then
+        print *, "[Error: failed to pack timestamp96"
+        stop 1
+    end if
+    ! expect 15 bytes
+    allocate(b_var_temp(15))
+    b_var_temp(1) = MP_E8
+    b_var_temp(2) = 12
+    b_var_temp(3) = -1
+    b_var_temp(4) = 0
+    b_var_temp(5) = 0
+    b_var_temp(6) = 4
+    b_var_temp(7) = -46 ! 0xd2
+    b_var_temp(8) = -1
+    b_var_temp(9) = -1
+    b_var_temp(10) = -1
+    b_var_temp(11) = -1
+    b_var_temp(12) = -1
+    b_var_temp(13) = -1
+    b_var_temp(14) = -8 ! 0xf8
+    b_var_temp(15) = 48 ! 0x30
+    if (size(buf) == 15) then
+        do i = 1,15
+            if (buf(i) /= b_var_temp(i)) then
+                print *, "[Error: packed timestamp96 byte[]", i, "] ==", buf(i), "Expected:", b_6_temp(i)
+                stop 1
+            end if
+        end do
+    else
+        print *, "[Error: failed to pack timestamp96. Size:", size(buf), "Expected: 15"
+        stop 1
+    end if
+    deallocate(buf)
+    deallocate(b_var_temp)
+    deallocate(ts_test)
+    print *, "[Info: timestamp96 packing test succeeded"
 
 end program

--- a/test/unpacking.f90
+++ b/test/unpacking.f90
@@ -3,6 +3,7 @@ program unpacking
     implicit none
 
     ! variables to use
+    class(mp_settings), allocatable :: mp_s
     byte, allocatable, dimension(:) :: stream ! buffer of bytes
     class(mp_value_type), allocatable :: mpv  ! pointer to value
     integer :: i, i_tmp
@@ -20,11 +21,12 @@ program unpacking
 
     print *, "Unpacking test"
     call print_endianness()
+    mp_s = mp_settings()
 
     ! positive fix int test: VALUE = 45
     allocate(stream(1))
     stream(1) = 45
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream (PFI)"
@@ -45,7 +47,7 @@ program unpacking
     ! negative fix int test: VALUE = -2
     allocate(stream(1))
     stream(1) = -30 ! 0b11100010 as int8
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream (NFI)"
@@ -70,7 +72,7 @@ program unpacking
     stream(3) = -102_int8 ! 0x9a
     stream(4) =  -55_int8 ! 0xc9
     stream(5) =   -1_int8 ! 0xff
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream(UInt32)"
@@ -101,7 +103,7 @@ program unpacking
     stream(7) =    0 ! 0x00
     stream(8) =    5 ! 0x05
     stream(9) =   65 ! 0x41
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream(UInt64 big)"
@@ -129,7 +131,7 @@ program unpacking
     stream(3) = 101 ! e
     stream(4) = 103 ! g
     stream(5) = 111 ! o
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream(fixstr)"
@@ -158,7 +160,7 @@ program unpacking
     stream(4) = MP_I16 ! int 16 byte mark
     stream(5) = 125 ! 0x7d
     stream(6) = 0   ! 0x00
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream(fixarr)"
@@ -230,7 +232,7 @@ program unpacking
     stream(27) = ior(MP_FA_L, 2) ! fixarr byte mark
     stream(28) =   4 ! positive fix int
     stream(29) = -30 ! 0b11100010 as int8
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream(fixmap)"
@@ -324,7 +326,7 @@ program unpacking
     do i = 1,i_tmp
         stream(i + 2) = int(i, kind=int8)
     end do
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream(bin)"
@@ -355,7 +357,7 @@ program unpacking
     do i = 1,i_tmp
         stream(i + 3) = int(modulo(i, 35), kind=int8)
     end do
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream(bin)"
@@ -388,7 +390,7 @@ program unpacking
     do i = 1,i_tmp
         stream(i + 5) = int(modulo(i, 25) * modulo(i, 14), kind=int8)
     end do
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream(bin)"
@@ -417,7 +419,7 @@ program unpacking
     stream(2) = 4 ! type
     stream(3) = 2 ! data
 
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream(ext)"
@@ -456,7 +458,7 @@ program unpacking
     stream(3) = -1 ! data
     stream(4) = -2
 
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream(ext)"
@@ -497,7 +499,7 @@ program unpacking
     stream(5) = 100
     stream(6) = -20
 
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream(ext)"
@@ -533,7 +535,7 @@ program unpacking
         stream(2+i) = int(i, kind=int8)
     end do
 
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream(ext)"
@@ -569,7 +571,7 @@ program unpacking
         stream(2+i) = int(-i, kind=int8)
     end do
 
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream(ext)"
@@ -606,7 +608,7 @@ program unpacking
     stream(5) = 2
     stream(6) = 3
 
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream(ext)"
@@ -648,7 +650,7 @@ program unpacking
         stream(4 + i) = int(401 - i, kind=int8)
     end do
 
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream(ext)"
@@ -694,7 +696,7 @@ program unpacking
         stream(6 + i) = int(modulo(i, 3_int8), kind=int8)
     end do
 
-    call unpack_stream(stream, mpv, status)
+    call unpack_stream(mp_s, stream, mpv, status)
     deallocate(stream)
     if (.not.(status)) then
         print *, "[Error: issue occurred with unpacking stream(ext)"


### PR DESCRIPTION
- Adds in support for custom user defined extensions
- Adds in `mp_timestamp_type` as a library type that is implemented with the user extensions
- Adds the `mp_settings` object
   - meant to hold the registration of the functions used for user extensions
   - I think I can later refactor things to hold more settings within it
   - All unpacking code & tests refactored to use it
- Bumps version to `0.1.1`

Todo:
- [x] documentation
- [x] packing tests