### PR TITLE
16 arr map tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 
 project('fortran-messagepack', ['fortran'],
-    version : '0.1.1')
+    version : '0.1.2')
 
 my_lib = shared_library('messagepack',
     'src/messagepack.f90',

--- a/src/messagepack_unpack.f90
+++ b/src/messagepack_unpack.f90
@@ -626,7 +626,7 @@ module messagepack_unpack
             type is (mp_value_type)
             class is (mp_ext_type)
                 mpv%values = buffer(byteadvance:byteadvance+length-1)
-                byteadvance = byteadvance + length
+                byteadvance = byteadvance + length - 1
             class default
                 successful = .false.
                 deallocate(mpv)

--- a/src/messagepack_unpack.f90
+++ b/src/messagepack_unpack.f90
@@ -124,7 +124,7 @@ module messagepack_unpack
                 byteadvance = 1 + btemp1
             case (MP_NIL)
                 ! default is already nil
-                return
+                mpv = mp_nil_type()
             case (MP_NU)
                 print *, "Error, never used detected"
                 successful = .false.

--- a/src/messagepack_unpack.f90
+++ b/src/messagepack_unpack.f90
@@ -146,11 +146,12 @@ module messagepack_unpack
                 select type (mpv)
                 type is (mp_value_type)
                 class is (mp_bin_type)
-                    mpv%value(:) = buffer(3:)
+                    mpv%value(:) = buffer(3:2+val_int64)
                 class default
                     successful = .false.
                     print *, "[Error: something went terribly wrong"
                 end select
+                byteadvance = 2 + val_int64
             case (MP_B16)
                 ! check that the remaining number of bytes exist
                 val_int16 = bytes_be_to_int_2(buffer(2:3), is_little_endian)
@@ -164,11 +165,12 @@ module messagepack_unpack
                 select type (mpv)
                 type is (mp_value_type)
                 class is (mp_bin_type)
-                    mpv%value(:) = buffer(4:)
+                    mpv%value(:) = buffer(4:3+val_int64)
                 class default
                     successful = .false.
                     print *, "[Error: something went terribly wrong"
                 end select
+                byteadvance = 3 + val_int64
             case (MP_B32)
                 ! check that the remaining number of bytes exist
                 val_int32 = bytes_be_to_int_4(buffer(2:5), is_little_endian)
@@ -182,11 +184,12 @@ module messagepack_unpack
                 select type (mpv)
                 type is (mp_value_type)
                 class is (mp_bin_type)
-                    mpv%value(:) = buffer(6:)
+                    mpv%value(:) = buffer(6:5+val_int64)
                 class default
                     successful = .false.
                     print *, "[Error: something went terribly wrong"
                 end select
+                byteadvance = 5 + val_int64
             case (MP_E8)
                 ! check for first 3 bytes
                 if (.not. check_length_and_print(3_int64, length)) then


### PR DESCRIPTION
- Adds bug fixes for the binary format family
   - fixes value assignment in constructor during unpacking
   - fixes byteadvance calculation
- Adds bug fixes for the extension format family
   - fixes byteadvance calculation for default types
- Adds packing & unpacking tests for: `array16`, `array32`, `map16`, `map32`
- Uprevs patch version to indicate bug fixes

Closes https://github.com/Sinfaen/fortran-messagepack/issues/16