### PR TITLE
17 build manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# Build directories
+*build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.15.0)
+
+project(fortran_messagepack
+    VERSION 0.1.2
+    LANGUAGES Fortran)
+
+add_subdirectory(src)
+add_subdirectory(app/simple-demo)
+add_subdirectory(test)
+enable_testing()
+
+# tests
+add_test(NAME constructors
+    COMMAND ./test/constructors)
+add_test(NAME packing
+    COMMAND ./test/packing)
+add_test(NAME unpacking
+    COMMAND ./test/unpacking)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15.0)
 
 project(fortran_messagepack
-    VERSION 0.1.2
+    VERSION 0.1.3
     LANGUAGES Fortran)
 
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # fortran-messagepack
-Prototype library for messagepack support in fortran. A shared library with the basename `messagepack` is compiled. 
+Library for [MessagePack](https://msgpack.org/) support in fortran.
 
-Utilizes OOP.
+## Supported Build Systems
+| Build System | Targets | Known Working Versions |
+| --- | --- | --- |
+| Meson | messagepack | 0.61.2 |
+| CMake | messagepack | 3.22.1 |
+| FPM | . | 0.9.0, alpha |
 
 ## Requirements
 - Fortran 2008
-- `meson` build system (only one supported for now)
+   - OOP utilized heavily
 
 ## Examples
-
 ### Unpacking
 ```fortran
 program test

--- a/app/simple-demo/CMakeLists.txt
+++ b/app/simple-demo/CMakeLists.txt
@@ -1,0 +1,5 @@
+# simple demo
+add_executable(simple-demo main.f90)
+target_include_directories(simple-demo PUBLIC
+    ${CMAKE_BINARY_DIR}/modules)
+target_link_libraries(simple-demo messagepack)

--- a/app/simple-demo/main.f90
+++ b/app/simple-demo/main.f90
@@ -1,0 +1,44 @@
+! Example demonstrating roundtrip serialization
+! & deserialization.
+program simple_demo
+    use messagepack
+    implicit none
+
+    ! variables
+    class(mp_map_type), allocatable :: mp_map
+    logical :: error
+    class(mp_settings), allocatable :: mp_s
+    byte, dimension(:), allocatable :: buffer
+
+
+    print *, 'Simple MessagePack Demo'
+
+    mp_s = mp_settings()
+
+    ! map assigning id's to types of rodents
+    mp_map = mp_map_type(4_int64) ! pairs
+    mp_map%keys(1)%obj   = mp_str_type("rat")
+    mp_map%values(1)%obj = mp_int_type(5)
+    mp_map%keys(2)%obj   = mp_str_type("gerbil")
+    mp_map%values(2)%obj = mp_int_type(2)
+    mp_map%keys(3)%obj   = mp_str_type("capybara")
+    mp_map%values(3)%obj = mp_int_type(11)
+    mp_map%keys(4)%obj   = mp_str_type("jerboa")
+    mp_map%values(4)%obj = mp_int_type(2)
+
+    ! print the structure to the user
+    print *, "MessagePack map object to be serialized"
+    call print_messagepack(mp_map)
+
+    ! pack the data
+    call pack_alloc(mp_map, buffer, error)
+    if (error) then
+        print *, "[Error: failed to pack mp_map"
+        stop 1
+    end if
+    ! print the buffer
+    print *, "Serialized Data:"
+    print *, buffer
+
+    deallocate(buffer)
+end program

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,5 +1,5 @@
 name = "fortran_messagepack"
-version = "0.1.2"
+version = "0.1.3"
 license="MIT"
 author="Kelly Schultz"
 maintainer="ksjaculus@gmail.com"

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,0 +1,27 @@
+name = "fortran_messagepack"
+version = "0.1.2"
+license="MIT"
+author="Kelly Schultz"
+maintainer="ksjaculus@gmail.com"
+copyright="Copyright 2023, Kelly Schultz"
+description="Implements an API for serializing & deserializing MessagePack"
+
+[[executable]]
+name = "simple-demo"
+source-dir = "app/simple-demo"
+main = "main.f90"
+
+[[test]]
+name = "constructors"
+source-dir = "test"
+main = "constructors.f90"
+
+[[test]]
+name = "packing"
+source-dir = "test"
+main = "packing.f90"
+
+[[test]]
+name = "unpacking"
+source-dir = "test"
+main = "unpacking.f90"

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 
 project('fortran_messagepack', ['fortran'],
-    version : '0.1.2')
+    version : '0.1.3')
 
 my_lib = shared_library('messagepack',
     'src/messagepack.f90',

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 
-project('fortran-messagepack', ['fortran'],
+project('fortran_messagepack', ['fortran'],
     version : '0.1.2')
 
 my_lib = shared_library('messagepack',
@@ -24,3 +24,8 @@ e3 = executable('packing',
     'test/packing.f90',
     dependencies : [my_dep])
 test('packing', e3)
+
+# demo executables
+simple_demo = executable('simple-demo',
+    'app/simple-demo/main.f90',
+    dependencies : [my_dep])

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,10 @@
+# build the fortran-messagepack library
+add_library(messagepack SHARED
+    messagepack.f90
+    messagepack_value.f90
+    messagepack_user.f90
+    messagepack_pack.f90
+    messagepack_unpack.f90
+    byte_utilities.f90)
+set_target_properties(messagepack PROPERTIES
+    Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/modules)

--- a/src/messagepack_unpack.f90
+++ b/src/messagepack_unpack.f90
@@ -568,7 +568,11 @@ module messagepack_unpack
             end if
 
             ! Custom extension handling
-            ind = etype + 128
+            ind = etype + 129
+            if (ind < 1 .or. ind > 256) then
+                successful = .false.
+                return
+            end if
             if (length == 1) then
                 if (settings%f1_allocated(ind)) then
                     call settings%f1(ind)%cb(buffer, byteadvance, &

--- a/src/messagepack_user.f90
+++ b/src/messagepack_user.f90
@@ -138,7 +138,7 @@ module messagepack_user
 
             integer :: arr_index
 
-            arr_index = typeid + 128 ! [-128, 127] -> [1, 256]
+            arr_index = typeid + 129 ! [-128, 127] -> [1, 256]
 
             select case(ext)
             case (MP_FE1)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,20 @@
+# constructor test
+add_executable(constructors
+    constructors.f90)
+target_include_directories(constructors PUBLIC
+    ${CMAKE_BINARY_DIR}/modules)
+target_link_libraries(constructors messagepack)
+
+# packing test
+add_executable(packing
+    packing.f90)
+target_include_directories(packing PUBLIC
+    ${CMAKE_BINARY_DIR}/modules)
+target_link_libraries(packing messagepack)
+
+# unpacking test
+add_executable(unpacking
+    unpacking.f90)
+target_include_directories(unpacking PUBLIC
+    ${CMAKE_BINARY_DIR}/modules)
+target_link_libraries(unpacking messagepack)


### PR DESCRIPTION
# Adds CMake & FPM Build Support
the fortran package manager requires a regular executable to build, so I what I did was add a simple demo in `app/simple-demo`. This should be an easy way to show how the library works. I'm using [fhash](https://github.com/LKedward/fhash) as inspiration for this. I should go ask the fortran community for the best way to handle installation procedures.

## Changes
- adds a bug fix for index calculation with the extension unpacking logic
- adds `app/simple-demo/main.f90` with some basic serialization and printing
- updates `.gitignore` to ignore all `*build` folders
- adds `fpm.toml`, testing with `0.9.0, alpha`
- adds CMake build, testing with `3.22.1`

TODO:
- [x] unpacking tests is failing in FPM ?
- [x] update README for the various builds
- [x] get simple-demo working in CMake

Closes https://github.com/Sinfaen/fortran-messagepack/issues/17