### PR TITLE
31 improve debug tooling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15.0)
 
 project(fortran_messagepack
-    VERSION 0.1.3
+    VERSION 0.1.4
     LANGUAGES Fortran)
 
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Library for [MessagePack](https://msgpack.org/) support in fortran.
 | CMake | messagepack | 3.22.1 |
 | FPM | . | 0.9.0, alpha |
 
+Known to work with `gfortran` 9.4.0 and above.
+
 ## Requirements
 - Fortran 2008
    - OOP utilized heavily

--- a/app/simple-demo/main.f90
+++ b/app/simple-demo/main.f90
@@ -38,7 +38,7 @@ program simple_demo
     end if
     ! print the buffer
     print *, "Serialized Data:"
-    print *, buffer
+    call print_bytes_as_hex(buffer)
 
     deallocate(buffer)
 end program

--- a/app/simple-demo/main.f90
+++ b/app/simple-demo/main.f90
@@ -6,6 +6,8 @@ program simple_demo
 
     ! variables
     class(mp_map_type), allocatable :: mp_map
+    class(mp_arr_type), allocatable :: mp_arr
+    class(mp_bin_type), allocatable :: mp_bin
     logical :: error
     class(mp_settings), allocatable :: mp_s
     byte, dimension(:), allocatable :: buffer
@@ -15,20 +17,31 @@ program simple_demo
 
     mp_s = mp_settings()
 
-    ! map assigning id's to types of rodents
-    mp_map = mp_map_type(4_int64) ! pairs
+    ! complicated example
+    mp_arr = mp_arr_type(3_int64)
+    mp_arr%value(1)%obj = new_real32(5.01)
+    mp_arr%value(2)%obj = new_real32(-21.2)
+    mp_arr%value(3)%obj = new_real32(700.0)
+
+    mp_bin = mp_bin_type(2_int64)
+    mp_bin%value(1) = -2
+    mp_bin%value(2) = 35
+
+    mp_map = mp_map_type(5_int64) ! pairs
     mp_map%keys(1)%obj   = mp_str_type("rat")
     mp_map%values(1)%obj = mp_int_type(5)
     mp_map%keys(2)%obj   = mp_str_type("gerbil")
-    mp_map%values(2)%obj = mp_int_type(2)
+    mp_map%values(2)%obj = mp_bin
     mp_map%keys(3)%obj   = mp_str_type("capybara")
     mp_map%values(3)%obj = mp_int_type(11)
     mp_map%keys(4)%obj   = mp_str_type("jerboa")
     mp_map%values(4)%obj = mp_int_type(2)
+    mp_map%keys(5)%obj   = mp_bool_type(.true.)
+    mp_map%values(5)%obj = mp_arr
 
     ! print the structure to the user
     print *, "MessagePack map object to be serialized"
-    call print_messagepack(mp_map)
+    call mp_s%print_value(mp_map)
 
     ! pack the data
     call pack_alloc(mp_map, buffer, error)
@@ -38,7 +51,10 @@ program simple_demo
     end if
     ! print the buffer
     print *, "Serialized Data:"
-    call print_bytes_as_hex(buffer)
+    call print_bytes_as_hex(buffer, .true.)
 
     deallocate(buffer)
+    deallocate(mp_map)
+    deallocate(mp_arr)
+    deallocate(mp_bin)
 end program

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,5 +1,5 @@
 name = "fortran_messagepack"
-version = "0.1.3"
+version = "0.1.4"
 license="MIT"
 author="Kelly Schultz"
 maintainer="ksjaculus@gmail.com"

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 
 project('fortran_messagepack', ['fortran'],
-    version : '0.1.3')
+    version : '0.1.4')
 
 my_lib = shared_library('messagepack',
     'src/messagepack.f90',

--- a/src/messagepack.f90
+++ b/src/messagepack.f90
@@ -15,7 +15,7 @@ module messagepack
     implicit none
 contains
     subroutine print_version()
-        print *, "0.0.1"
+        print *, "0.1.3"
     end subroutine
 
     subroutine print_messagepack(obj)
@@ -90,6 +90,22 @@ contains
         if (.not. sameline) then
             print *, ""
         end if
+    end subroutine
+
+    subroutine print_bytes_as_hex(bytes)
+        ! prints a buffer of bytes as the unsigned hex version
+        ! @param[in] bytes - byte buffer to print
+        ! @returns none
+        byte, dimension(:), allocatable, intent(in) :: bytes
+
+        integer :: i
+        integer :: val
+        write(*, "(A2)", advance="no") "[ "
+        do i = 1,size(bytes)
+            val = int8_as_unsigned(bytes(i))
+            write(*, '(Z2.2, " ")', advance="no") val
+        end do
+        write(*,*) "]"
     end subroutine
 
 end module

--- a/src/messagepack.f90
+++ b/src/messagepack.f90
@@ -18,93 +18,28 @@ contains
         print *, "0.1.3"
     end subroutine
 
-    subroutine print_messagepack(obj)
-        class(mp_value_type) :: obj
-        call print_messagepack_with_args(obj, 0, .false.)
-    end subroutine
-
-    recursive subroutine print_messagepack_with_args(obj, indentation, sameline)
-        class(mp_value_type), intent(in) :: obj
-        integer, intent(in) :: indentation
-        logical, intent(in) :: sameline
-        integer(kind=int64) :: i, j
-
-        if (.not. sameline) then
-            do i = 1,indentation
-                write(*, "(A)", advance="no") char(9)
-            end do
-        end if
-
-        select type(obj)
-        type is (mp_value_type)
-        class is (mp_nil_type)
-            write(*, "(A)", advance="no") "nil"
-        class is (mp_bool_type)
-            if (obj%value) then
-                write(*, "(A)", advance="no") "true"
-            else
-                write(*, "(A)", advance="no") "false"
-            end if
-        class is (mp_int_type)
-            if (obj%unsigned_64) then
-                write(*, "(I0, A)", advance="no") obj%value, "[OUT-OF-RANGE]"
-            else
-                write(*, "(I0)", advance="no") obj%value
-            end if
-            
-        class is (mp_float_type)
-            if (obj%is_64) then
-                write(*, "(F0.0)", advance="no") obj%f64value
-            else
-                write(*, "(F0.0)", advance="no") obj%f32value
-            end if
-        class is (mp_str_type)
-            write(*, "(A, A, A)", advance="no") char(34), obj%value, char(34)
-        class is (mp_bin_type)
-            print *, "binary value TODO"
-        class is (mp_arr_type)
-            write(*, "(A, I0, A)") "array[", obj%numelements(), "]"
-            do i = 1,indentation+1
-                write(*, "(A)", advance="no") char(9)
-            end do
-            write(*, "(A)", advance="no") "["
-            do j = 1,obj%numelements()
-                call print_messagepack_with_args(obj%value(j)%obj, 0, .true.)
-                write(*, "(A)", advance="no") ", " 
-            end do
-            write(*, "(A)", advance="no") "]" 
-        class is (mp_map_type)
-            write(*, "(A, I0, A)") "map[", obj%numelements(), "]"
-            do j = 1, obj%numelements()
-                do i = 1,indentation+1
-                    write(*, "(A)", advance="no") char(9)
-                end do
-                call print_messagepack_with_args(obj%keys(j)%obj, indentation + 1, .true.)
-                write(*, "(A)", advance="no") " => "
-                call print_messagepack_with_args(obj%values(j)%obj, indentation + 1, .true.)
-                print *, ""
-            end do
-        class is (mp_ext_type)
-            print *, "ext value TODO"
-        end select
-        if (.not. sameline) then
-            print *, ""
-        end if
-    end subroutine
-
-    subroutine print_bytes_as_hex(bytes)
+    subroutine print_bytes_as_hex(bytes, addhexmark)
         ! prints a buffer of bytes as the unsigned hex version
         ! @param[in] bytes - byte buffer to print
+        ! @param[in] addhexmark - If true, print with 0x prepended
         ! @returns none
         byte, dimension(:), allocatable, intent(in) :: bytes
+        logical, intent(in) :: addhexmark
 
         integer :: i
         integer :: val
         write(*, "(A2)", advance="no") "[ "
-        do i = 1,size(bytes)
-            val = int8_as_unsigned(bytes(i))
-            write(*, '(Z2.2, " ")', advance="no") val
-        end do
+        if (addhexmark) then
+            do i = 1,size(bytes)
+                val = int8_as_unsigned(bytes(i))
+                write(*, '("0x", Z2.2, " ")', advance="no") val
+            end do
+        else
+            do i = 1,size(bytes)
+                val = int8_as_unsigned(bytes(i))
+                write(*, '(Z2.2, " ")', advance="no") val
+            end do
+        end if
         write(*,*) "]"
     end subroutine
 


### PR DESCRIPTION
- improves the output of the debug functions
- adds a debug function for printing the `byte, dimension(:)` representation of serialized messagepack as hex
- the binary format family packing was basically broken. fixed here
- Expands documentation
- Uprevs version