### PR TITLE
27 generic interfaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15.0)
 
 project(fortran_messagepack
-    VERSION 0.2.0
+    VERSION 0.3.0
     LANGUAGES Fortran)
 
 add_subdirectory(src)

--- a/app/simple-demo/main.f90
+++ b/app/simple-demo/main.f90
@@ -48,6 +48,7 @@ program simple_demo
     call mp%pack_alloc(mp_map, buffer)
     if (mp%failed()) then
         print *, "[Error: failed to pack mp_map"
+        print *, mp%error_message
         stop 1
     end if
     ! print the buffer

--- a/app/simple-demo/main.f90
+++ b/app/simple-demo/main.f90
@@ -28,7 +28,7 @@ program simple_demo
     mp_bin%value(1) = -2
     mp_bin%value(2) = 35
 
-    mp_map = mp_map_type(5_int64) ! pairs
+    mp_map = mp_map_type(6_int64) ! pairs
     mp_map%keys(1)%obj   = mp_str_type("rat")
     mp_map%values(1)%obj = mp_int_type(5)
     mp_map%keys(2)%obj   = mp_str_type("gerbil")
@@ -39,6 +39,8 @@ program simple_demo
     mp_map%values(4)%obj = mp_int_type(2)
     mp_map%keys(5)%obj   = mp_bool_type(.true.)
     mp_map%values(5)%obj = mp_arr
+    mp_map%keys(6)%obj   = mp_int_type(0)
+    mp_map%values(6)%obj = mp_int_type(-11)
 
     ! print the structure to the user
     print *, "MessagePack map object to be serialized"

--- a/app/simple-demo/main.f90
+++ b/app/simple-demo/main.f90
@@ -20,13 +20,13 @@ program simple_demo
 
     ! complicated example
     mp_arr = mp_arr_type(3_int64)
-    mp_arr%value(1)%obj = new_real32(5.01)
-    mp_arr%value(2)%obj = new_real32(-21.2)
-    mp_arr%value(3)%obj = new_real32(700.0)
+    mp_arr%values(1)%obj = mp_float_type(5.01)
+    mp_arr%values(2)%obj = mp_float_type(-21.2)
+    mp_arr%values(3)%obj = mp_float_type(700.0)
 
     mp_bin = mp_bin_type(2_int64)
-    mp_bin%value(1) = -2
-    mp_bin%value(2) = 35
+    mp_bin%values(1) = -2
+    mp_bin%values(2) = 35
 
     mp_map = mp_map_type(6_int64) ! pairs
     mp_map%keys(1)%obj   = mp_str_type("rat")

--- a/fpm.toml
+++ b/fpm.toml
@@ -1,5 +1,5 @@
 name = "fortran_messagepack"
-version = "0.2.0"
+version = "0.3.0"
 license="MIT"
 author="Kelly Schultz"
 maintainer="ksjaculus@gmail.com"

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 
 project('fortran_messagepack', ['fortran'],
-    version : '0.2.0')
+    version : '0.3.0')
 
 my_lib = shared_library('messagepack',
     'src/messagepack.f90',

--- a/src/messagepack.f90
+++ b/src/messagepack.f90
@@ -62,7 +62,7 @@ contains
         l = arr%numelements()
         allocate(om(l))
         do i = 1,l
-            call get_int(arr%value(i)%obj, val, stat)
+            call get_int(arr%values(i)%obj, val, stat)
             if (.not.(stat)) then
                 return
             end if
@@ -95,7 +95,7 @@ contains
         l = arr%numelements()
         allocate(om(l))
         do i = 1,l
-            call get_real(arr%value(i)%obj, val, stat)
+            call get_real(arr%values(i)%obj, val, stat)
             if (.not.(stat)) then
                 return
             end if

--- a/src/messagepack_user.f90
+++ b/src/messagepack_user.f90
@@ -989,9 +989,8 @@ module messagepack_user
                 call this%unpack_map(val_int64, buffer, byteadvance, &
                     mpv, successful)
             case (MP_NFI_L:MP_NFI_H)
-                ! take the first 5 bits, create a negative value from it
-                btemp1 = ibits(buffer(1), 0, 5)
-                mpv = mp_int_type(-btemp1)
+                ! it's the straight bit pattern there
+                mpv = mp_int_type(buffer(1))
             end select
         end subroutine
 

--- a/src/messagepack_user.f90
+++ b/src/messagepack_user.f90
@@ -336,7 +336,7 @@ module messagepack_user
             class is (mp_arr_type)
                 write(*, "(A)", advance="no") "["
                 printarr : do j = 1,obj%numelements()
-                    call this%print_value_with_args(obj%value(j)%obj, 0, .true., maxelems)
+                    call this%print_value_with_args(obj%values(j)%obj, 0, .true., maxelems)
                     write(*, "(A)", advance="no") ", "
                     if (maxelems > 0 .and. j > maxelems) then
                         write(*, "(A3)") "..."
@@ -370,7 +370,7 @@ module messagepack_user
             class is (mp_bin_type)
                 write(*, "(A)", advance="no") "BIN["
                 printbin : do j = 1,obj%numelements()
-                    write(*, "(I0, A)", advance="no") obj%value(j), ", "
+                    write(*, "(I0, A)", advance="no") obj%values(j), ", "
                     if (maxelems > 0 .and. j > maxelems) then
                         write(*, "(A)") "..."
                         exit printbin
@@ -652,7 +652,7 @@ module messagepack_user
                 select type (mpv)
                 type is (mp_value_type)
                 class is (mp_bin_type)
-                    mpv%value(:) = buffer(3:2+val_int64)
+                    mpv%values(:) = buffer(3:2+val_int64)
                 class default
                     successful = .false.
                     this%error_message = 'internal error - bin8 cast'
@@ -672,7 +672,7 @@ module messagepack_user
                 select type (mpv)
                 type is (mp_value_type)
                 class is (mp_bin_type)
-                    mpv%value(:) = buffer(4:3+val_int64)
+                    mpv%values(:) = buffer(4:3+val_int64)
                 class default
                     successful = .false.
                     this%error_message = 'internal error - bin16 bad cast'
@@ -692,7 +692,7 @@ module messagepack_user
                 select type (mpv)
                 type is (mp_value_type)
                 class is (mp_bin_type)
-                    mpv%value(:) = buffer(6:5+val_int64)
+                    mpv%values(:) = buffer(6:5+val_int64)
                 class default
                     successful = .false.
                     this%error_message = 'internal error - bin32 bad cast'
@@ -1019,7 +1019,7 @@ module messagepack_user
                 select type (mpv)
                 type is (mp_value_type)
                 class is (mp_arr_type)
-                    mpv%value(i)%obj = val_any
+                    mpv%values(i)%obj = val_any
                 class default
                     successful = .false.
                     deallocate(mpv)

--- a/src/messagepack_user.f90
+++ b/src/messagepack_user.f90
@@ -135,7 +135,7 @@ module messagepack_user
 
         subroutine print_version(this)
             class(msgpack) :: this
-            print *, "0.2.0"
+            print *, "0.3.0"
         end subroutine
 
         logical function failed(this)

--- a/src/messagepack_user.f90
+++ b/src/messagepack_user.f90
@@ -269,11 +269,11 @@ module messagepack_user
             if (byteadvance < size(buffer) .and. this%extra_bytes) then
                 ! configurable error
                 this%fail_flag = .true.
-                print *, "[Warning: Extra", size(buffer) - byteadvance, "bytes unused"
+                write(this%error_message, '(i0) (A)') size(buffer) - byteadvance, ' extra bytes unused'
             else if (byteadvance > size(buffer)) then
                 this%fail_flag = .true. ! bug within reporting byte mechanism
-                print *, "[Error: internal error byteadvance beyond buffer length"
-                print *, byteadvance, "=/=", size(buffer)
+                write(this%error_message, '(A) (i0)') "internal error. number of bytes exceeds buffer size by: ", &
+                    byteadvance - size(buffer)
             end if
         end subroutine
 

--- a/src/messagepack_value.f90
+++ b/src/messagepack_value.f90
@@ -487,8 +487,8 @@ module messagepack_value
             error = .false.
             if (this%value < 0) then
                 if (this%value >= -32) then
-                    ! negative fixint
-                    buf(1) = int(-32 - this%value, kind=int8)
+                    ! negative fixint - copy bits over
+                    buf(1) = int(this%value, kind=int8)
                 else if (this%value >= -128) then
                     ! int8
                     buf(1) = MP_I8

--- a/test/constructors.f90
+++ b/test/constructors.f90
@@ -19,19 +19,19 @@ program constructors
     nil_test  = mp_nil_type()
     bool_test = mp_bool_type(.true.)
     int_test  = mp_int_type(45)
-    float_test = new_real32(-23.1)
+    float_test = mp_float_type(-23.1)
     str_test = mp_str_type("hello world")
 
     ! array contructor test
-    arr_test = mp_arr_type(5_int64)
-    arr_test%value(1)%obj = mp_nil_type()
-    arr_test%value(2)%obj = mp_bool_type(.true.)
-    arr_test%value(3)%obj = mp_int_type(45)
-    arr_test%value(4)%obj = new_real32(-51.4)
-    arr_test%value(5)%obj = mp_arr_type(2_int64)
+    arr_test = mp_arr_type(5)
+    arr_test%values(1)%obj = mp_nil_type()
+    arr_test%values(2)%obj = mp_bool_type(.true.)
+    arr_test%values(3)%obj = mp_int_type(45)
+    arr_test%values(4)%obj = new_real32(-51.4)
+    arr_test%values(5)%obj = mp_arr_type(2)
 
     ! map constructor test
-    map_test = mp_map_type(4_int64)
+    map_test = mp_map_type(4)
     map_test%keys(1)%obj   = mp_int_type(34)
     map_test%values(1)%obj = mp_str_type("tokay gecko")
     map_test%keys(2)%obj   = mp_int_type(10)
@@ -42,10 +42,10 @@ program constructors
     map_test%values(4)%obj = mp_nil_type()
 
     ! binary constructor test
-    bin_test = mp_bin_type(3_int64)
-    bin_test%value(1) = 3
-    bin_test%value(2) = -2
-    bin_test%value(3) = 4
+    bin_test = mp_bin_type(3)
+    bin_test%values(1) = 3
+    bin_test%values(2) = -2
+    bin_test%values(3) = 4
 
     ! extension constructor test
     ext_test = mp_ext_type(40, 7_int64)

--- a/test/packing.f90
+++ b/test/packing.f90
@@ -40,6 +40,7 @@ program packing
     call mp%pack_alloc(int_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack int"
+        print *, mp%error_message
         stop 1
     end if
     ! we expect a single byte that contains the value 4
@@ -61,6 +62,7 @@ program packing
     call mp%pack_alloc(int_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack NFI"
+        print *, mp%error_message
         stop 1
     end if
     ! we expect a single byte that contains the value -27 (0b11100101 as int8)
@@ -86,6 +88,7 @@ program packing
     call mp%pack_alloc(str_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack Str8"
+        print *, mp%error_message
         stop 1
     end if
     length = len(small_text)
@@ -127,6 +130,7 @@ program packing
     call mp%pack_alloc(arr_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack fixarray"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 22 bytes
@@ -154,6 +158,7 @@ program packing
     call mp%pack_alloc(arr_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack array16"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 16387 bytes
@@ -192,6 +197,7 @@ program packing
     call mp%pack_alloc(arr_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack array32"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 2^20 * 2 +_ 5 bytes
@@ -244,6 +250,7 @@ program packing
     call mp%pack_alloc(map_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack fixmap"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 21 bytes
@@ -272,6 +279,7 @@ program packing
     call mp%pack_alloc(map_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack map16"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 3 + 16 + 16 bytes
@@ -323,6 +331,7 @@ program packing
     call mp%pack_alloc(map_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack map32"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 5 + 65536 * 5 * 2 bytes
@@ -346,6 +355,7 @@ program packing
             call mp%unpack(buf(j:j + 4), mp_val)
             if (mp%failed()) then
                 print *, "[Error: failed to unpack map32 key at", i
+                print *, mp%error_message
                 stop 1
             end if
             call get_real(mp_val, rval, success)
@@ -361,6 +371,7 @@ program packing
             call mp%unpack(buf(j+5:j+9), mp_val)
             if (mp%failed()) then
                 print *, "[Error: failed to unpack map32 value at", i
+                print *, mp%error_message
             end if
             call get_real(mp_val, rval, success)
             if (.not. success) then
@@ -384,6 +395,7 @@ program packing
     call mp%pack_alloc(ext_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack fixext1"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 3 bytes
@@ -411,6 +423,7 @@ program packing
     call mp%pack_alloc(ext_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack fixext2"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 4 bytes
@@ -440,6 +453,7 @@ program packing
     call mp%pack_alloc(ext_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack fixext4"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 6 bytes
@@ -473,6 +487,7 @@ program packing
     call mp%pack_alloc(ext_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack fixext8"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 10 bytes
@@ -501,6 +516,7 @@ program packing
     call mp%pack_alloc(ext_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack fixext16"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 18 bytes
@@ -529,6 +545,7 @@ program packing
     call mp%pack_alloc(ext_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack ext8"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 18 bytes
@@ -557,6 +574,7 @@ program packing
     call mp%pack_alloc(ext_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack ext16"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 304 bytes
@@ -593,6 +611,7 @@ program packing
     call mp%pack_alloc(ext_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack ext32"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 70006 bytes
@@ -628,6 +647,7 @@ program packing
     call mp%pack_alloc(ts_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack timestamp32"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 6 bytes
@@ -652,6 +672,7 @@ program packing
     call mp%pack_alloc(ts_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack timestamp64"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 10 bytes
@@ -687,6 +708,7 @@ program packing
     call mp%pack_alloc(ts_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack timestamp96"
+        print *, mp%error_message
         stop 1
     end if
     ! expect 15 bytes

--- a/test/packing.f90
+++ b/test/packing.f90
@@ -46,11 +46,11 @@ program packing
     ! we expect a single byte that contains the value 4
     if (size(buf) == 1) then
         if (buf(1) /= 4_int8) then
-            print *, "[Error: failed to pack NFI. byte(1): ", buf(1)
+            print *, "[Error: failed to pack PFI. byte(1): ", buf(1)
             stop 1
         end if
     else
-        print *, "[Error: failed to pack NFI. Size: ", size(buf)
+        print *, "[Error: failed to pack PFI. Size: ", size(buf)
         stop 1
     end if
     deallocate(buf)
@@ -67,7 +67,7 @@ program packing
     end if
     ! we expect a single byte that contains the value -27 (0b11100101 as int8)
     if (size(buf) == 1) then
-        if (buf(1) /= -27_int8) then
+        if (buf(1) /= -5_int8) then
             print *, "[Error: failed to pack NFI. byte(1): ", buf(1)
             stop 1
         end if
@@ -295,9 +295,9 @@ program packing
             stop 1
         end if
         do i = 1,16
-            if (buf(3 + 2*i - 1) /= -32 + i) then
+            if (buf(3 + 2*i - 1) /= -i) then
                 print *, "[Error: failed to pack map16 key at index", i
-                print *, "Found", buf(3+2*i-1), "Expected", -32 + i
+                print *, "Found", buf(3+2*i-1), "Expected", -i
                 stop 1
             end if
             if (modulo(i, 2) == 1) then ! false

--- a/test/packing.f90
+++ b/test/packing.f90
@@ -20,7 +20,6 @@ program packing
     integer :: i
     integer :: j
     integer :: length
-    logical :: errored
     logical :: success
     real(kind=real64) :: rval
 
@@ -122,11 +121,11 @@ program packing
     print *, "[Info: Str8 packing test succeeded"
 
     ! fixarray test
-    arr_test = mp_arr_type(4_int64)
-    arr_test%value(1)%obj = new_real32(32.1)
-    arr_test%value(2)%obj = new_real64(-2.03_8)
-    arr_test%value(3)%obj = mp_str_type("mochi")
-    arr_test%value(4)%obj = mp_bool_type(.true.)
+    arr_test = mp_arr_type(4)
+    arr_test%values(1)%obj = mp_float_type(32.1)
+    arr_test%values(2)%obj = mp_float_type(-2.03_8)
+    arr_test%values(3)%obj = mp_str_type("mochi")
+    arr_test%values(4)%obj = mp_bool_type(.true.)
     call mp%pack_alloc(arr_test, buf)
     if (mp%failed()) then
         print *, "[Error: failed to pack fixarray"
@@ -151,9 +150,9 @@ program packing
     ! array16 test
     ! 2^14 elements: all PFI values within [3,123]
     ! - use PFI so that the binary checking is easy
-    arr_test = mp_arr_type(16384_int64)
+    arr_test = mp_arr_type(16384)
     do i = 1,16384
-        arr_test%value(i)%obj = mp_int_type(modulo(i, 120) + 3)
+        arr_test%values(i)%obj = mp_int_type(modulo(i, 120) + 3)
     end do
     call mp%pack_alloc(arr_test, buf)
     if (mp%failed()) then
@@ -192,7 +191,7 @@ program packing
     ! all uint8 elements [200:255]. allows easy binary checking
     arr_test = mp_arr_type(1048576_int64)
     do i = 1,1048576
-        arr_test%value(i)%obj = mp_int_type(199 + modulo(i, 57))
+        arr_test%values(i)%obj = mp_int_type(199 + modulo(i, 57))
     end do
     call mp%pack_alloc(arr_test, buf)
     if (mp%failed()) then
@@ -237,13 +236,13 @@ program packing
     print *, "[Info: array32 packing test succeeded"
 
     ! fixmap test
-    arr_test = mp_arr_type(1_int64)
-    arr_test%value(1)%obj = mp_str_type("a")
+    arr_test = mp_arr_type(1)
+    arr_test%values(1)%obj = mp_str_type("a")
 
-    map_test = mp_map_type(3_int64)
-    map_test%keys(1)%obj   = new_real32(21.1)
+    map_test = mp_map_type(3)
+    map_test%keys(1)%obj   = mp_float_type(21.1)
     map_test%values(1)%obj = mp_bool_type(.false.)
-    map_test%keys(2)%obj   = new_real64(74.1_real64)
+    map_test%keys(2)%obj   = mp_float_type(74.1_real64)
     map_test%values(2)%obj = mp_nil_type()
     map_test%keys(3)%obj   = mp_int_type(3)
     map_test%values(3)%obj = arr_test
@@ -271,7 +270,7 @@ program packing
     ! map16 test
     ! keys = NFI -1:-16
     ! values = [.false., .true., ...]
-    map_test = mp_map_type(16_int64)
+    map_test = mp_map_type(16)
     do i = 1,16
         map_test%keys(i)%obj = mp_int_type(-i)
         map_test%values(i)%obj = mp_bool_type(modulo(i, 2) == 0)
@@ -325,8 +324,8 @@ program packing
     ! values = real32 ( log(1:65536) )
     map_test = mp_map_type(65536_int64)
     do i = 1,65536
-        map_test%keys(i)%obj   = new_real32(i + 0.0)
-        map_test%values(i)%obj = new_real32(log(i + 0.0))
+        map_test%keys(i)%obj   = mp_float_type(i + 0.0)
+        map_test%values(i)%obj = mp_float_type(log(i + 0.0))
     end do
     call mp%pack_alloc(map_test, buf)
     if (mp%failed()) then
@@ -511,7 +510,7 @@ program packing
     ! fixext16 test
     ext_test = mp_ext_type(-128, 16_int64)
     do i=1,16
-        ext_test%values(i) = i*i - 10*i
+        ext_test%values(i) = int(i*i - 10*i, kind=int8)
     end do
     call mp%pack_alloc(ext_test, buf)
     if (mp%failed()) then

--- a/test/roundtrip.f90
+++ b/test/roundtrip.f90
@@ -48,6 +48,7 @@ program roundtrip
     call mp%pack_alloc(mp_map, buffer)
     if (mp%failed()) then
         print *, "[Error: failed to pack map#1"
+        print *, mp%error_message
         stop 1
     end if
 
@@ -55,6 +56,7 @@ program roundtrip
     call mp%unpack(buffer, val)
     if (mp%failed()) then
         print *, "[Error: failed to unpack map#1"
+        print *, mp%error_message
         stop 1
     end if
     ! check equality
@@ -132,6 +134,7 @@ program roundtrip
     call mp%pack_alloc(mp_arr, buffer)
     if (mp%failed()) then
         print *, "[Error: failed to pack arr#1"
+        print *, mp%error_message
         stop 1
     end if
 
@@ -139,6 +142,7 @@ program roundtrip
     call mp%unpack(buffer, val)
     if (mp%failed()) then
         print *, "[Error: failed to unpack arr#1"
+        print *, mp%error_message
         stop 1
     end if
 

--- a/test/roundtrip.f90
+++ b/test/roundtrip.f90
@@ -32,11 +32,11 @@ program roundtrip
     mp = msgpack()
 
     ! map test 1
-    mp_arr = mp_arr_type(2_int64)
-    mp_arr%value(1)%obj = new_real32(3.4)
-    mp_arr%value(2)%obj = new_real32(7.5)
+    mp_arr = mp_arr_type(2)
+    mp_arr%values(1)%obj = new_real32(3.4)
+    mp_arr%values(2)%obj = new_real32(7.5)
 
-    mp_map = mp_map_type(3_int64)
+    mp_map = mp_map_type(3)
     mp_map%keys(1)%obj = mp_int_type(4)
     mp_map%values(1)%obj = mp_str_type("hello world")
     mp_map%keys(2)%obj = mp_int_type(11)
@@ -111,24 +111,24 @@ program roundtrip
     print *, "[Info: map roundtrip test #1 succeeded"
 
     ! array test 1
-    mp_arr = mp_arr_type(9_int64)
-    mp_bin = mp_bin_type(300_int64)
+    mp_arr = mp_arr_type(9)
+    mp_bin = mp_bin_type(300)
     do i = 1,300
-        mp_bin%value(i) = int(modulo(i, 55), kind=int8)
+        mp_bin%values(i) = int(modulo(i, 55), kind=int8)
     end do
     mp_ext = mp_ext_type(25, 70000_int64)
     do i = 1,70000
         mp_ext%values(i) = int(modulo(i, 73), kind=int8)
     end do
-    mp_arr%value(1)%obj = mp_str_type("foo")
-    mp_arr%value(2)%obj = mp_nil_type()
-    mp_arr%value(3)%obj = mp_timestamp_type(10, 300)
-    mp_arr%value(4)%obj = mp_bin
-    mp_arr%value(5)%obj = mp_bool_type(.false.)
-    mp_arr%value(6)%obj = mp_ext
-    mp_arr%value(7)%obj = mp_int_type(-2000000000_int64)
-    mp_arr%value(8)%obj = new_real64(3.1415926535_real64)
-    mp_arr%value(9)%obj = mp_bool_type(.true.)
+    mp_arr%values(1)%obj = mp_str_type("foo")
+    mp_arr%values(2)%obj = mp_nil_type()
+    mp_arr%values(3)%obj = mp_timestamp_type(10, 300)
+    mp_arr%values(4)%obj = mp_bin
+    mp_arr%values(5)%obj = mp_bool_type(.false.)
+    mp_arr%values(6)%obj = mp_ext
+    mp_arr%values(7)%obj = mp_int_type(-2000000000_int64)
+    mp_arr%values(8)%obj = new_real64(3.1415926535_real64)
+    mp_arr%values(9)%obj = mp_bool_type(.true.)
 
     ! serialize
     call mp%pack_alloc(mp_arr, buffer)
@@ -156,21 +156,21 @@ program roundtrip
         print *, "[Error: incorrect array size"
         stop 1
     end if
-    call get_str(arr_temp%value(1)%obj, str_temp, error)
+    call get_str(arr_temp%values(1)%obj, str_temp, error)
     if (.not.(error) .or. str_temp /= "foo") then
         print *, "[Error: arr 1"
         stop 1
     end if
-    if (.not.(is_nil(arr_temp%value(2)%obj))) then
+    if (.not.(is_nil(arr_temp%values(2)%obj))) then
         print *, "[Error: arr 2"
         stop 1
     end if
-    call get_timestamp_ref(arr_temp%value(3)%obj, mp_ts, error)
+    call get_timestamp_ref(arr_temp%values(3)%obj, mp_ts, error)
     if (.not.(error) .or. mp_ts%seconds /= 10 .or. mp_ts%nanoseconds /= 300) then
         print *, "[Error: arr 3"
         stop 1
     end if
-    call get_bin(arr_temp%value(4)%obj, byte_temp, error)
+    call get_bin(arr_temp%values(4)%obj, byte_temp, error)
     if (error) then
         if (size(byte_temp) == 300) then
             do i = 1,300
@@ -187,12 +187,12 @@ program roundtrip
         print *, "[Error: arr 4 not a bin"
         stop 1
     end if
-    call get_bool(arr_temp%value(5)%obj, b_temp, error)
+    call get_bool(arr_temp%values(5)%obj, b_temp, error)
     if (.not.(error) .or. b_temp .neqv. .false.) then
         print *, "[Error: arr 5"
         stop 1
     end if
-    call get_ext_ref(arr_temp%value(6)%obj, ext_temp, error)
+    call get_ext_ref(arr_temp%values(6)%obj, ext_temp, error)
     if (error .and. ext_temp%numelements() == 70000) then
         do i = 1,70000
             if (ext_temp%values(i) /= modulo(i, 73)) then
@@ -204,17 +204,17 @@ program roundtrip
         print *, "[Error: arr 6 ext inv"
         stop 1
     end if
-    call get_int(arr_temp%value(7)%obj, i_temp, error)
+    call get_int(arr_temp%values(7)%obj, i_temp, error)
     if (.not.(error) .or. i_temp /= -2000000000_int64) then
         print *, "[Error: arr 7"
         stop 1
     end if
-    call get_real(arr_temp%value(8)%obj, r_temp, error)
+    call get_real(arr_temp%values(8)%obj, r_temp, error)
     if (.not.(error) .or. r_temp /= 3.1415926535_real64) then
         print *, "[Error: arr 8"
         stop 1
     end if
-    call get_bool(arr_temp%value(9)%obj, b_temp, error)
+    call get_bool(arr_temp%values(9)%obj, b_temp, error)
     if (.not.(error) .or. b_temp .neqv. .true.) then
         print *, "[Error: arr 9"
         stop 1

--- a/test/unpacking.f90
+++ b/test/unpacking.f90
@@ -48,7 +48,7 @@ program unpacking
 
     ! negative fix int test: VALUE = -2
     allocate(stream(1))
-    stream(1) = -30 ! 0b11100010 as int8
+    stream(1) = -2
     call mp%unpack(stream, mpv)
     deallocate(stream)
     if (mp%failed()) then
@@ -162,7 +162,7 @@ program unpacking
     allocate(stream(6))
     stream(1) = ior(MP_FA_L, 3) ! fixarray byte mark
     stream(2) = 12  ! positive fix int
-    stream(3) = -29 ! negative fix int: 0b11100011 as int8
+    stream(3) = -3  ! negative fix int
     stream(4) = MP_I16 ! int 16 byte mark
     stream(5) = 125 ! 0x7d
     stream(6) = 0   ! 0x00
@@ -331,8 +331,8 @@ program unpacking
     stream(25) = 0  ! 0x00
     stream(26) = MP_T
     stream(27) = ior(MP_FA_L, 2) ! fixarr byte mark
-    stream(28) =   4 ! positive fix int
-    stream(29) = -30 ! 0b11100010 as int8
+    stream(28) =  4 ! positive fix int
+    stream(29) = -2 ! negative fix int
     call mp%unpack(stream, mpv)
     deallocate(stream)
     if (mp%failed()) then
@@ -429,7 +429,7 @@ program unpacking
     stream(3) = 0
     do i = 1,8192
         ! key
-        stream(4+4*(i-1)) = int(-32 + modulo(i, 11), kind=int8)
+        stream(4+4*(i-1)) = -int(modulo(i, 11), kind=int8)
         ! value
         stream(5+4*(i-1)) = MP_FE1
         stream(6+4*(i-1)) = 2

--- a/test/unpacking.f90
+++ b/test/unpacking.f90
@@ -31,6 +31,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream (PFI)"
+        print *, mp%error_message
         stop 1
     end if
     if (.not.(is_int(mpv))) then
@@ -52,6 +53,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream (NFI)"
+        print *, mp%error_message
         stop 1
     end if
     if (.not.(is_int(mpv))) then
@@ -77,6 +79,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(UInt32)"
+        print *, mp%error_message
         stop 1
     end if
     if (.not.(is_int(mpv))) then
@@ -108,6 +111,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(UInt64 big)"
+        print *, mp%error_message
         stop 1
     end if
     if (.not.(is_int(mpv))) then
@@ -136,6 +140,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(fixstr)"
+        print *, mp%error_message
         stop 1
     end if
     if (.not.(is_str(mpv))) then
@@ -165,6 +170,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(fixarr)"
+        print *, mp%error_message
         stop 1
     end if
     ! check length of the array
@@ -211,6 +217,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: unpacking stream(array16)"
+        print *, mp%error_message
         stop 1
     end if
     ! check length
@@ -258,6 +265,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: unpacking stream(array32)"
+        print *, mp%error_message
         stop 1
     end if
     ! check length
@@ -329,6 +337,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(fixmap)"
+        print *, mp%error_message
         stop 1
     end if
     if (mpv%numelements() /= 3) then
@@ -430,6 +439,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(map16)"
+        print *, mp%error_message
         stop 1
     end if
     if (mpv%numelements() /= 8192) then
@@ -490,6 +500,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(map32)"
+        print *, mp%error_message
         stop 1
     end if
     if (mpv%numelements() /= 262144) then
@@ -543,6 +554,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(bin)"
+        print *, mp%error_message
         stop 1
     end if
     ! check that binary was unpacked
@@ -574,6 +586,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(bin)"
+        print *, mp%error_message
         stop 1
     end if
     ! check that binary was unpacked
@@ -607,6 +620,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(bin)"
+        print *, mp%error_message
         stop 1
     end if
     ! check that binary was unpacked
@@ -636,6 +650,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(ext)"
+        print *, mp%error_message
         stop 1
     end if
     ! check that ext was unpacked
@@ -675,6 +690,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(ext)"
+        print *, mp%error_message
         stop 1
     end if
     ! check that ext was unpacked
@@ -716,6 +732,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(ext)"
+        print *, mp%error_message
         stop 1
     end if
     ! check that ext was unpacked
@@ -752,6 +769,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(ext)"
+        print *, mp%error_message
         stop 1
     end if
     ! check that ext was unpacked
@@ -788,6 +806,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(ext)"
+        print *, mp%error_message
         stop 1
     end if
     ! check that ext was unpacked
@@ -825,6 +844,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(ext)"
+        print *, mp%error_message
         stop 1
     end if
     ! check that ext was unpacked
@@ -867,6 +887,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(ext)"
+        print *, mp%error_message
         stop 1
     end if
     ! check that ext was unpacked
@@ -913,6 +934,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking stream(ext)"
+        print *, mp%error_message
         stop 1
     end if
     ! check that ext was unpacked
@@ -956,6 +978,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking (timestamp32)"
+        print *, mp%error_message
         stop 1
     end if
     ! check that timestamp was unpacked
@@ -993,6 +1016,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking (timestamp64)"
+        print *, mp%error_message
         stop 1
     end if
     ! check that timestamp was unpacked
@@ -1036,6 +1060,7 @@ program unpacking
     deallocate(stream)
     if (mp%failed()) then
         print *, "[Error: issue occurred with unpacking (timestamp96)"
+        print *, mp%error_message
         stop 1
     end if
     ! check that timestamp was unpacked

--- a/test/unpacking.f90
+++ b/test/unpacking.f90
@@ -188,11 +188,11 @@ program unpacking
 
     ! loop over all elements
     do i = 1,3
-        if (.not. is_int(arrtmp%value(i)%obj)) then
+        if (.not. is_int(arrtmp%values(i)%obj)) then
             print *, "[Error: fixarray[", i, "] is not an int"
             stop 1
         end if
-        call get_int(arrtmp%value(i)%obj, itmp, status)
+        call get_int(arrtmp%values(i)%obj, itmp, status)
         if (itmp /= i_a_3(i)) then
             print *, "[Error: unpacked ", itmp, "instead of", i_a_3(i), "for fixarray > ", i
         end if
@@ -233,7 +233,7 @@ program unpacking
     end if
     ! check elements
     do i = 1,16
-        call get_bool(arrtmp%value(i)%obj, btmp, status)
+        call get_bool(arrtmp%values(i)%obj, btmp, status)
         if (.not.(status)) then
             print *, "[Error: array16", i, "is not a boolean"
             stop 1
@@ -243,7 +243,7 @@ program unpacking
             stop 1
         end if
     end do
-    if (.not.(is_nil(arrtmp%value(17)%obj))) then
+    if (.not.(is_nil(arrtmp%values(17)%obj))) then
         print *, "[Error: array16(17) is not nil"
         stop 1
     end if
@@ -281,7 +281,7 @@ program unpacking
     end if
     ! check elements
     do i = 1,1048576
-        call get_bin(arrtmp%value(i)%obj, byte_tmp, status)
+        call get_bin(arrtmp%values(i)%obj, byte_tmp, status)
         if (.not.(status)) then
             print *, "[Error: unpacked array32", i, "is not a bin"
             stop 1
@@ -406,11 +406,11 @@ program unpacking
     call get_arr_ref(maptmp%values(3)%obj, arrtmp, status)
     i_a_2 = (/4, -2/)
     do i = 1,2
-        if (.not. is_int(arrtmp%value(i)%obj)) then
+        if (.not. is_int(arrtmp%values(i)%obj)) then
             print *, "[Error: fixmap[3] value[", i, "] is not an int"
             stop 1
         end if
-        call get_int(arrtmp%value(i)%obj, itmp, status)
+        call get_int(arrtmp%values(i)%obj, itmp, status)
         if (itmp /= i_a_2(i)) then
             print *, "[Error: fixmap[3] value[", i, "] was not ", i_a_2(i)
             stop 1


### PR DESCRIPTION
- fixes bug due to misunderstanding with negative fix integers
- simplifies interface for `mp_float_type` so that it matches the others
- adds constructors for the containers that accepts regular `integer` for ease of use
- adds in `error_message` as a member of `msgpack` that stores error messages instead of being printed to console
- `value` changed to `values` in the arr and bin types
- updated tests
- uprev to `0.3.0`

Closes https://github.com/Sinfaen/fortran-messagepack/issues/27