### PR TITLE
Update build-system versions that have been tested, copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Kelly Schultz
+Copyright (c) 2025 Kelly Schultz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Library for [MessagePack](https://msgpack.org/) support in fortran.
 ## Supported Build Systems
 | Build System | Targets | Known Working Versions |
 | --- | --- | --- |
-| Meson | messagepack | 0.61.2 |
-| CMake | messagepack | 3.22.1 |
-| FPM | . | 0.9.0, alpha |
+| Meson | messagepack | 1.3.2 |
+| CMake | messagepack | 3.28.3 |
+| FPM | . | 0.10.1, alpha |
 
-Known to work with `gfortran` 9.4.0 and above.
+Known to work with `gfortran` 13.3.0 and above.
 
 ## Requirements
 - Fortran 2008

--- a/fpm.toml
+++ b/fpm.toml
@@ -3,7 +3,7 @@ version = "0.3.1"
 license="MIT"
 author="Kelly Schultz"
 maintainer="ksjaculus@gmail.com"
-copyright="Copyright 2023, Kelly Schultz"
+copyright="Copyright 2025, Kelly Schultz"
 description="Implements an API for serializing & deserializing MessagePack"
 
 [[executable]]


### PR DESCRIPTION
## Changes
- Update copyright to 2025
- Update recorded versions of build system tests

## Notes
- tested with updated versions of cmake, fpm, meson